### PR TITLE
Updated python to 3.14.6 on alpine 3.24.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -23,8 +23,8 @@ steps:
         from_secret: docker_password
       repo: kernel528/python
       tags:
-        - 3.14.2
-        - 3.14.2-drone-build-${DRONE_BUILD_NUMBER}
+        - 3.14.6
+        - 3.14.6-drone-build-${DRONE_BUILD_NUMBER}
 
   # Slack notification
   - name: slack-notification

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,11 @@
 ## Build, Test, and Development Commands
 - Build locally:
   ```sh
-  docker build -t kernel528/python:3.14.2 -f Dockerfile .
+  docker build -t kernel528/python:3.14.6 -f Dockerfile .
   ```
 - Run a quick smoke test:
   ```sh
-  docker run -it --rm --name python3 kernel528/python:3.14.2 python --version
+  docker run -it --rm --name python3 kernel528/python:3.14.6 python --version
   ```
 
 ## Coding Style & Naming Conventions

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kernel528/alpine:3.23.3
+FROM kernel528/alpine:3.24.1
 
 LABEL maintainer=kernel528@gmail.com
 
@@ -15,8 +15,8 @@ RUN set -eux; \
 		tzdata \
 	;
 
-ENV PYTHON_VERSION 3.14.2
-ENV PYTHON_SHA256 ce543ab854bc256b61b71e9b27f831ffd1bfd60a479d639f8be7f9757cf573e9
+ENV PYTHON_VERSION 3.14.6
+ENV PYTHON_SHA256 143b1dddefaec3bd2e21e3b839b34a2b7fb9842272883c576420d605e9f30c63
 
 RUN set -eux; \
 	\

--- a/README.md
+++ b/README.md
@@ -5,19 +5,19 @@
 [![Docker Image Size (tag)](https://img.shields.io/docker/image-size/kernel528/python)](https://hub.docker.com/r/kernel528/python)
 
 ## Overview
-- Base image: `kernel528/alpine:3.23.3`
+- Base image: `kernel528/alpine:3.24.1`
 - This repo tracks Python 3.14 on Alpine.
-- Upstream reference: https://github.com/docker-library/python/blob/master/3.14/alpine3.23/Dockerfile
+- Upstream reference: https://github.com/docker-library/python/blob/master/3.14/alpine3.24/Dockerfile
 
 ## Build
 ```
-docker image build -t kernel528/python:3.14.2 -f Dockerfile .
+docker image build -t kernel528/python:3.14.6 -f Dockerfile .
 ```
 
 ## Run
 - By default the image runs `python3`. You can pass python logic as command input to the container, or run it interactively.
 ```
-docker run -it --rm --name python3 --hostname python3 kernel528/python:3.14.2
+docker run -it --rm --name python3 --hostname python3 kernel528/python:3.14.6
 Python 3.14.2 (main, ... ) [GCC ...] on linux
 Type "help", "copyright", "credits" or "license" for more information.
 >>> print("Hello World")
@@ -27,8 +27,8 @@ Hello World
 
 ## Smoke test
 ```
-docker run --rm kernel528/python:3.14.2 python --version
-docker run --rm kernel528/python:3.14.2 python - <<'PY'
+docker run --rm kernel528/python:3.14.6 python --version
+docker run --rm kernel528/python:3.14.6 python - <<'PY'
 print("ok")
 PY
 ```

--- a/VERSION.md
+++ b/VERSION.md
@@ -28,3 +28,4 @@
 * v3.14.0 - Updated to python v3.14.0 and kernel528/alpine:3.22.2  Tagged:  kernel528/python:3.14.0
 * v3.14.2 - Updated to python v3.14.2 and kernel528/alpine:3.22.2  Tagged:  kernel528/python:3.14.2
 * v3.14.2-3.23.3 - Updated base image to kernel528/alpine:3.23.3. Tagged: kernel528/python:3.14.2
+* v3.14.6-3.24.1 - Updated to python v3.14.6 and kernel528/alpine:3.24.1. Tagged: kernel528/python:3.14.6


### PR DESCRIPTION
Updates:

- **Python**: 3.14.2 → 3.14.6 (SHA `143b1dddefaec3bd2e21e3b839b34a2b7fb9842272883c576420d605e9f30c63`)
- **Base image**: `kernel528/alpine:3.23.3` → `kernel528/alpine:3.24.1`
- `.drone.yml`, `README.md`, `VERSION.md`, `AGENTS.md` version references refreshed

Validation:

- `docker image build --no-cache` succeeded
- `python --version` → `Python 3.14.6`
- `pip --version` → `pip 26.1.2`
- `cat /etc/alpine-release` → `3.24.1`
- Python REPL smoke test passed