### PR TITLE
Rebase Python 3.14.6 on Alpine 3.24.1_1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,6 +25,8 @@ steps:
       tags:
         - 3.14.6
         - 3.14.6-drone-build-${DRONE_BUILD_NUMBER}
+        - 3.14.6-3.24.1_1
+        - 3.14.6-3.24.1_1-drone-build-${DRONE_BUILD_NUMBER}
 
   # Slack notification
   - name: slack-notification

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,11 @@
 ## Build, Test, and Development Commands
 - Build locally:
   ```sh
-  docker build -t kernel528/python:3.14.6 -f Dockerfile .
+  docker build -t kernel528/python:3.14.6-3.24.1_1 -f Dockerfile .
   ```
 - Run a quick smoke test:
   ```sh
-  docker run -it --rm --name python3 kernel528/python:3.14.6 python --version
+  docker run -it --rm --name python3 kernel528/python:3.14.6-3.24.1_1 python --version
   ```
 
 ## Coding Style & Naming Conventions

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kernel528/alpine:3.24.1
+FROM kernel528/alpine:3.24.1_1
 
 LABEL maintainer=kernel528@gmail.com
 

--- a/README.md
+++ b/README.md
@@ -5,19 +5,19 @@
 [![Docker Image Size (tag)](https://img.shields.io/docker/image-size/kernel528/python)](https://hub.docker.com/r/kernel528/python)
 
 ## Overview
-- Base image: `kernel528/alpine:3.24.1`
+- Base image: `kernel528/alpine:3.24.1_1`
 - This repo tracks Python 3.14 on Alpine.
 - Upstream reference: https://github.com/docker-library/python/blob/master/3.14/alpine3.24/Dockerfile
 
 ## Build
 ```
-docker image build -t kernel528/python:3.14.6 -f Dockerfile .
+docker image build -t kernel528/python:3.14.6-3.24.1_1 -f Dockerfile .
 ```
 
 ## Run
 - By default the image runs `python3`. You can pass python logic as command input to the container, or run it interactively.
 ```
-docker run -it --rm --name python3 --hostname python3 kernel528/python:3.14.6
+docker run -it --rm --name python3 --hostname python3 kernel528/python:3.14.6-3.24.1_1
 Python 3.14.2 (main, ... ) [GCC ...] on linux
 Type "help", "copyright", "credits" or "license" for more information.
 >>> print("Hello World")
@@ -27,8 +27,8 @@ Hello World
 
 ## Smoke test
 ```
-docker run --rm kernel528/python:3.14.6 python --version
-docker run --rm kernel528/python:3.14.6 python - <<'PY'
+docker run --rm kernel528/python:3.14.6-3.24.1_1 python --version
+docker run --rm kernel528/python:3.14.6-3.24.1_1 python - <<'PY'
 print("ok")
 PY
 ```

--- a/VERSION.md
+++ b/VERSION.md
@@ -29,3 +29,4 @@
 * v3.14.2 - Updated to python v3.14.2 and kernel528/alpine:3.22.2  Tagged:  kernel528/python:3.14.2
 * v3.14.2-3.23.3 - Updated base image to kernel528/alpine:3.23.3. Tagged: kernel528/python:3.14.2
 * v3.14.6-3.24.1 - Updated to python v3.14.6 and kernel528/alpine:3.24.1. Tagged: kernel528/python:3.14.6
+* v3.14.6-3.24.1_1 - Rebuilt Python 3.14.6 on kernel528/alpine:3.24.1_1. Tagged: kernel528/python:3.14.6-3.24.1_1


### PR DESCRIPTION
## Summary
- rebase Python 3.14.6 on kernel528/alpine:3.24.1_1
- retain the application-version tag and add a base-qualified immutable tag
- update Drone outputs, README, version history, and repository guidance

## Validation status
Blocked on native Linux Mint validation. Source download, SHA256 verification, and configuration succeeded on macOS arm64; QEMU later terminated GCC during linux/amd64 compilation.

Required on Linux Mint before marking ready:

```bash
docker image build --no-cache --platform linux/amd64 -t kernel528/python:3.14.6-3.24.1_1 -f Dockerfile .
docker container run --rm kernel528/python:3.14.6-3.24.1_1 python --version
docker container run --rm kernel528/python:3.14.6-3.24.1_1 python -c 'import ssl, sqlite3; print("python-smoke=ok")'
```

Do not merge until these commands pass.